### PR TITLE
fix: skip unsupported performance counters in scrapePerformance

### DIFF
--- a/vmware/collectors/vmware.go
+++ b/vmware/collectors/vmware.go
@@ -164,13 +164,29 @@ func scrapePerformance(ctx context.Context, ch chan<- prometheus.Metric, logger 
 
 	begin := time.Now()
 
+	requestedCounters := len(counters)
+	supportedCounters := make([]string, 0, requestedCounters)
+	for _, counter := range counters {
+		if _, ok := countersSpec[counter]; ok {
+			supportedCounters = append(supportedCounters, counter)
+			continue
+		}
+
+		logger.Debug("performance counter not available, skipping", "counter", counter, "type", moType)
+	}
+
+	if len(supportedCounters) == 0 {
+		logger.Debug("no supported performance counters for scrape", "type", moType, "requested_counters", requestedCounters)
+		return
+	}
+
 	spec := types.PerfQuerySpec{
 		MaxSample:  sampleCount,                                // Number of samples to fetch - if samples are fetched every 20s only one is needed.
 		MetricId:   []types.PerfMetricId{{Instance: instance}}, //Instance takes either null string or * (or in fact any name of an performance manager metric instance)
 		IntervalId: sampleInterval,                             // 20 seconds
 	}
 
-	sample, err := perfManager.SampleByName(ctx, spec, counters, targetRefs)
+	sample, err := perfManager.SampleByName(ctx, spec, supportedCounters, targetRefs)
 	if err != nil {
 		logger.Error("error sampling metrics and targets", "error", err, "type", moType)
 		return


### PR DESCRIPTION
Make sure performance counters are available before trying to scape them.  Emit debug log if not.

```
time=2026-06-22T17:20:09.403Z level=ERROR source=vmware.go:175 msg="error sampling metrics and targets" collector=datastore error="counter \"disk.provisioned.latest\" not found" type=Datastore
```

becomes

```
time=2026-06-22T17:23:30.254Z level=DEBUG source=vmware.go:163 msg="gathering perfman metrics" collector=datastore target_ref=Datastore:5f633d56-82b0f020-3bc9-b02628cc5260 type=Datastore
time=2026-06-22T17:23:30.254Z level=DEBUG source=vmware.go:175 msg="performance counter not available, skipping" collector=datastore counter=disk.provisioned.latest type=Datastore
time=2026-06-22T17:23:30.254Z level=DEBUG source=vmware.go:175 msg="performance counter not available, skipping" collector=datastore counter=disk.used.latest type=Datastore
time=2026-06-22T17:23:30.254Z level=DEBUG source=vmware.go:179 msg="no supported performance counters for scrape" collector=datastore type=Datastore requested_counters=2
time=2026-06-22T17:23:30.254Z level=DEBUG source=collect.go:49 msg="collector scraped successfully" target=targethost name=datastore duration_seconds=0.035892865
```

(if log level set to debug)